### PR TITLE
Add badge for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # aas-core-protobuf
 
+[![CI](https://github.com/aas-core-works/aas-core-protobuf/actions/workflows/ci.yml/badge.svg)](https://github.com/aas-core-works/aas-core-protobuf/actions/workflows/ci.yml)
+
 Provide Protocol Buffer definitions for AAS meta-models.
 
 We put the definitions in the directories corresponding to the meta-model version:


### PR DESCRIPTION
We add a badge to README to signal that there is a continuous integration in place.